### PR TITLE
Add authentication for the `/import` endpoint call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-query": "^3.39.1",
         "react-router-dom": "^6.3.0",
         "source-map-support": "^0.5.21",
+        "sweetalert2": "^11.7.12",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -7186,6 +7187,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sweetalert2": {
+      "version": "11.7.12",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.7.12.tgz",
+      "integrity": "sha512-TQJy8mQymJLzqWPQOMQErd81Zd/rSYr0UL4pEc7bqEihtjS+zt7LWJXLhfPp93e+Hf3Z2FHMB6QGNskAMCsdTg==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-query": "^3.39.1",
     "react-router-dom": "^6.3.0",
     "source-map-support": "^0.5.21",
+    "sweetalert2": "^11.7.12",
     "yup": "^0.32.11"
   },
   "devDependencies": {

--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -31,6 +31,15 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
     }
     console.log("uploadFile to", url);
 
+    const authToken = localStorage.getItem("authorization_token");
+    let requestHeaders = {};
+
+    if (authToken !== null) {
+      requestHeaders = {
+        Authorization: `Basic ${authToken}`,
+      };
+    }
+
     // Get the presigned URL
     const response = await axios({
       method: "GET",
@@ -38,6 +47,7 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
       params: {
         name: encodeURIComponent(file.name),
       },
+      headers: requestHeaders,
     });
     console.log("File to upload: ", file.name);
     console.log("Uploading to: ", response.data.link);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import axios from "axios";
+import Swal from "sweetalert2";
 import { createRoot } from "react-dom/client";
 import App from "~/components/App/App";
 import CssBaseline from "@mui/material/CssBaseline";
@@ -18,6 +20,17 @@ if (import.meta.env.DEV) {
   const { worker } = await import("./mocks/browser");
   worker.start({ onUnhandledRequest: "bypass" });
 }
+
+axios.interceptors.response.use(
+  (x) => x,
+  (x) => {
+    console.log({ rej: x });
+    if (x.response.status === 401 || x.response.status === 403) {
+      Swal.fire("Unauthorized", x.response.statusText, "error");
+    }
+    throw x;
+  }
+);
 
 const container = document.getElementById("app");
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
* Task: https://github.com/rolling-scopes-school/aws/blob/main/aws-developer/07_authorization/task.md
* FE URL: https://d1xaanpmmg0wvm.cloudfront.net/admin/products

---

* Added axios interceptor to show alerts whenever request ends up with 401 or 403 status
* Added authorization header for uploading products CSV using token from local storage
